### PR TITLE
Fix webhook field conflicts and ensure idempotency

### DIFF
--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -243,7 +243,7 @@ func TestInjectWorkloadIdentityConfig(t *testing.T) {
 		assert.Contains(t, envNames, "GOOGLE_APPLICATION_CREDENTIALS")
 	})
 
-	t.Run("should fail when conflicting volume names exist", func(t *testing.T) {
+	t.Run("should skip injection when conflicting volume names exist", func(t *testing.T) {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-pod",
@@ -284,11 +284,11 @@ func TestInjectWorkloadIdentityConfig(t *testing.T) {
 			}
 		}
 		
-		// This assertion will fail, demonstrating the bug
-		assert.Equal(t, 1, tokenCount, "Should only have one 'token' volume, but found duplicates")
+		// This should now pass - webhook skips injection for conflicting volume names
+		assert.Equal(t, 1, tokenCount, "Should only have one 'token' volume - injection was skipped")
 	})
 
-	t.Run("should fail when conflicting mount paths exist", func(t *testing.T) {
+	t.Run("should skip injection when conflicting mount paths exist", func(t *testing.T) {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-pod",
@@ -321,11 +321,11 @@ func TestInjectWorkloadIdentityConfig(t *testing.T) {
 			}
 		}
 		
-		// This assertion will fail, demonstrating the bug
-		assert.Equal(t, 1, pathCount, "Should only have one mount at '/var/run/service-account', but found duplicates")
+		// This should now pass - webhook skips injection for conflicting mount paths
+		assert.Equal(t, 1, pathCount, "Should only have one mount at '/var/run/service-account' - injection was skipped")
 	})
 
-	t.Run("should fail when GOOGLE_APPLICATION_CREDENTIALS already exists", func(t *testing.T) {
+	t.Run("should skip injection when GOOGLE_APPLICATION_CREDENTIALS already exists", func(t *testing.T) {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-pod",
@@ -357,8 +357,8 @@ func TestInjectWorkloadIdentityConfig(t *testing.T) {
 			}
 		}
 		
-		// This assertion will fail, demonstrating the bug
-		assert.Equal(t, 1, credsCount, "Should only have one GOOGLE_APPLICATION_CREDENTIALS env var, but found duplicates")
+		// This should now pass - webhook skips injection for existing env vars
+		assert.Equal(t, 1, credsCount, "Should only have one GOOGLE_APPLICATION_CREDENTIALS env var - injection was skipped")
 	})
 
 }


### PR DESCRIPTION
## Problem

The webhook was blindly appending volumes, volume mounts, and environment variables without checking for existing fields. This caused:

- **Duplicate volume names** → Kubernetes rejects pods
- **Conflicting mount paths** → Container startup failures  
- **Multiple `GOOGLE_APPLICATION_CREDENTIALS`** → Undefined behavior

This violated the **idempotency** principle - a critical requirement for admission webhooks.

## Solution

Added comprehensive conflict detection with helper functions:

- `volumeExists()` - Check for existing volume names before injection
- `volumeMountExists()` - Check for existing volume mount names  
- `mountPathExists()` - Check for conflicting mount paths
- `envVarExists()` - Check for existing environment variables

The webhook now **gracefully skips injection** when conflicts exist instead of creating duplicates.

## Testing

- **First commit**: Added failing tests demonstrating the bug
- **Second commit**: Implemented the fix - all tests now pass

## Key Changes

1. **Before**: `pod.Spec.Volumes = append(...)`  → Always appends
2. **After**: `if !volumeExists(...) { append(...) }`  → Skip if exists

This ensures the webhook can be called multiple times safely without side effects.

## Impact

- ✅ **Idempotent** webhook behavior
- ✅ **No more pod rejections** from duplicate volume names
- ✅ **No more mount conflicts** causing container failures
- ✅ **Predictable behavior** with existing workloads
