### PR TITLE
fix: add RBAC permissions for Kubernetes events

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   - serviceaccounts
   verbs:

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -19,6 +19,7 @@ package v1
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 import (
 	"context"


### PR DESCRIPTION
Add missing events permissions to allow webhook to create events
for WIF injection conflicts. This enables kubectl visibility:

kubectl describe pod <pod-name>
kubectl get events --field-selector reason=WIFInjectionSkipped

Uses kubebuilder RBAC annotation for proper code generation:
// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
